### PR TITLE
Better search

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -59,6 +59,7 @@ nobase_dist_assets_DATA =                               \
   static/images/sort_desc.png                           \
   static/images/logo.png                                \
   static/images/cubes.png                               \
+  static/hpcguix-web.min.js                             \
   static/highlight/highlight.min.js                     \
   static/highlight/LICENSE                              \
   static/highlight/styles/androidstudio.css             \

--- a/environment.scm
+++ b/environment.scm
@@ -8,7 +8,7 @@
 ;;; Run the following command to enter a development environment for
 ;;; HPC Guix web:
 ;;;
-;;;  $ guix environment -l guix.scm
+;;;  $ guix environment -l environment.scm
 
 (use-modules ((guix licenses) #:prefix license:)
              (guix packages)

--- a/static/hpcguix-web.js
+++ b/static/hpcguix-web.js
@@ -1,0 +1,39 @@
+// @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-v3-or-later
+function feed_table(packages) {
+    var dt = $('#packages-table').DataTable({
+                sDom: 'lrtip',
+                data: packages,
+                processing: true,
+                createdRow: function (row, data, index) {
+                                $('#stand-by').hide();
+                                $('#packages-table').show();
+                            },
+                columns: [
+                    { data: 'name',
+                      mRender: function (data, type, full) {
+                                  return '<a href="package/' + data + '">' + data + '</a>';
+                               }
+                    },
+                    { data: 'version' },
+                    { data: 'synopsis' },
+                    { data: 'module',
+                      visible: false
+                    },
+                    { data: 'homepage',
+                      mRender: function (data, type, full) {
+                                  return '<a href="' + data + '">' + data + '</a>';
+                               }
+                    }
+                ]});
+    $('#search-field').on('keyup', function() {
+        dt.search(this.value).draw();
+    });
+    $('#search-field').on('keydown', function(event) {
+        if (event.which == 13) return false;
+    });
+}
+$(document).ready(function() {
+    $('#packages-table').hide();
+    $.getJSON('/packages.json', feed_table);
+});
+// @license-end

--- a/static/hpcguix-web.js
+++ b/static/hpcguix-web.js
@@ -1,4 +1,37 @@
 // @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-v3-or-later
+
+// Return a regular expression string without boundary slashes.
+function makeRegex (terms) {
+    var search = '^(?=.*?' + terms.join( ')(?=.*?' ) + ').*$';
+	return new RegExp(search, 'i').toString().slice(1,-2);
+}
+
+// Split a search string into a list of global search terms and
+// per-column search terms for any term that has a column name
+// followed by a colon as its prefix.
+function parseQuery(search, columns) {
+    var queries = {},
+        global = [];
+
+    search.split(' ').forEach(function (word) {
+        var term = word.split(':'),
+            columnName = false;
+
+        // Restrict search to specified column
+        if ((term.length > 1) &&
+            (columns.findIndex(function(el) { return el.data === term[0]; }) > -1)) {
+            columnName = term[0];
+            term = term.slice(1).join(':');
+
+            queries[columnName] ? queries[columnName].push(term) : queries[columnName] = [term];
+        } else {
+            global.push(word);
+        }
+    });
+
+    return [global, queries];
+}
+
 function feed_table(packages) {
     var dt = $('#packages-table').DataTable({
                 sDom: 'lrtip',
@@ -25,9 +58,28 @@ function feed_table(packages) {
                                }
                     }
                 ]});
+
+    // Filter the table on each key press.
     $('#search-field').on('keyup', function() {
-        dt.search(this.value).draw();
+        var columns = dt.settings().init().columns,
+            query = parseQuery(this.value, columns),
+            global = query[0],
+            perColumn = query[1];
+
+        // Set (or reset) per-column filters.
+        dt.columns().every(function (index) {
+            var name = columns[index].data;
+            if (perColumn.hasOwnProperty(name)) {
+                dt.column(index).search(makeRegex(perColumn[name]), true, false);
+            } else {
+                dt.column(index).search('', true, false);
+            }
+        });
+
+        // Set global filter.
+        dt.search(makeRegex(global), true, false).draw();
     });
+
     $('#search-field').on('keydown', function(event) {
         if (event.which == 13) return false;
     });

--- a/static/hpcguix-web.js
+++ b/static/hpcguix-web.js
@@ -1,91 +1,98 @@
 // @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-v3-or-later
+var hpcguix = (function () {
+    // Return a regular expression string without boundary slashes.
+    function makeRegex (terms) {
+        var search = '^(?=.*?' + terms.join( ')(?=.*?' ) + ').*$';
+	    return new RegExp(search, 'i').toString().slice(1,-2);
+    }
 
-// Return a regular expression string without boundary slashes.
-function makeRegex (terms) {
-    var search = '^(?=.*?' + terms.join( ')(?=.*?' ) + ').*$';
-	return new RegExp(search, 'i').toString().slice(1,-2);
-}
+    // Split a search string into a list of global search terms and
+    // per-column search terms for any term that has a column name
+    // followed by a colon as its prefix.
+    function parseQuery(search, columns) {
+        var queries = {},
+            global = [];
 
-// Split a search string into a list of global search terms and
-// per-column search terms for any term that has a column name
-// followed by a colon as its prefix.
-function parseQuery(search, columns) {
-    var queries = {},
-        global = [];
+        search.split(' ').forEach(function (word) {
+            var term = word.split(':'),
+                columnName = false;
 
-    search.split(' ').forEach(function (word) {
-        var term = word.split(':'),
-            columnName = false;
+            // Restrict search to specified column
+            if ((term.length > 1) &&
+                (columns.findIndex(function(el) { return el.data === term[0]; }) > -1)) {
+                columnName = term[0];
+                term = term.slice(1).join(':');
 
-        // Restrict search to specified column
-        if ((term.length > 1) &&
-            (columns.findIndex(function(el) { return el.data === term[0]; }) > -1)) {
-            columnName = term[0];
-            term = term.slice(1).join(':');
-
-            queries[columnName] ? queries[columnName].push(term) : queries[columnName] = [term];
-        } else {
-            global.push(word);
-        }
-    });
-
-    return [global, queries];
-}
-
-function feed_table(packages) {
-    var dt = $('#packages-table').DataTable({
-                sDom: 'lrtip',
-                data: packages,
-                processing: true,
-                createdRow: function (row, data, index) {
-                                $('#stand-by').hide();
-                                $('#packages-table').show();
-                            },
-                columns: [
-                    { data: 'name',
-                      mRender: function (data, type, full) {
-                                  return '<a href="package/' + data + '">' + data + '</a>';
-                               }
-                    },
-                    { data: 'version' },
-                    { data: 'synopsis' },
-                    { data: 'module',
-                      visible: false
-                    },
-                    { data: 'homepage',
-                      mRender: function (data, type, full) {
-                                  return '<a href="' + data + '">' + data + '</a>';
-                               }
-                    }
-                ]});
-
-    // Filter the table on each key press.
-    $('#search-field').on('keyup', function() {
-        var columns = dt.settings().init().columns,
-            query = parseQuery(this.value, columns),
-            global = query[0],
-            perColumn = query[1];
-
-        // Set (or reset) per-column filters.
-        dt.columns().every(function (index) {
-            var name = columns[index].data;
-            if (perColumn.hasOwnProperty(name)) {
-                dt.column(index).search(makeRegex(perColumn[name]), true, false);
+                queries[columnName] ? queries[columnName].push(term) : queries[columnName] = [term];
             } else {
-                dt.column(index).search('', true, false);
+                global.push(word);
             }
         });
 
-        // Set global filter.
-        dt.search(makeRegex(global), true, false).draw();
-    });
+        return [global, queries];
+    }
 
-    $('#search-field').on('keydown', function(event) {
-        if (event.which == 13) return false;
-    });
-}
-$(document).ready(function() {
-    $('#packages-table').hide();
-    $.getJSON('/packages.json', feed_table);
-});
+    function feed_table(packages) {
+        var dt = $('#packages-table').DataTable({
+            sDom: 'lrtip',
+            data: packages,
+            processing: true,
+            createdRow: function (row, data, index) {
+                $('#stand-by').hide();
+                $('#packages-table').show();
+            },
+            columns: [
+                { data: 'name',
+                  mRender: function (data, type, full) {
+                      return '<a href="package/' + data + '">' + data + '</a>';
+                  }
+                },
+                { data: 'version' },
+                { data: 'synopsis' },
+                { data: 'module',
+                  visible: false
+                },
+                { data: 'homepage',
+                  mRender: function (data, type, full) {
+                      return '<a href="' + data + '">' + data + '</a>';
+                  }
+                }
+            ]});
+
+        // Filter the table on each key press.
+        $('#search-field').on('keyup', function() {
+            var columns = dt.settings().init().columns,
+                query = parseQuery(this.value, columns),
+                global = query[0],
+                perColumn = query[1];
+
+            // Set (or reset) per-column filters.
+            dt.columns().every(function (index) {
+                var name = columns[index].data;
+                if (perColumn.hasOwnProperty(name)) {
+                    dt.column(index).search(makeRegex(perColumn[name]), true, false);
+                } else {
+                    dt.column(index).search('', true, false);
+                }
+            });
+
+            // Set global filter.
+            dt.search(makeRegex(global), true, false).draw();
+        });
+
+        $('#search-field').on('keydown', function(event) {
+            if (event.which == 13) return false;
+        });
+    }
+
+    // Initialize the packages table.
+    function init () {
+        $('#packages-table').hide();
+        $.getJSON('/packages.json', feed_table);
+    }
+
+    return {'init': init };
+})();
+
+$(document).ready(hpcguix.init);
 // @license-end

--- a/web-interface.scm
+++ b/web-interface.scm
@@ -1,4 +1,5 @@
 ;;; Copyright © 2016, 2017  Roel Janssen <roel@gnu.org>
+;;; Copyright © 2017  Ricardo Wurmus <rekado@elephly.net>
 ;;;
 ;;; This program is free software: you can redistribute it and/or
 ;;; modify it under the terms of the GNU Affero General Public License
@@ -102,7 +103,12 @@
                                     ("name"     ,(package-name package))
                                     ("version"  ,(package-version package))
                                     ("synopsis" ,(package-synopsis package))
-                                    ("homepage" ,(package-home-page package)))))))
+                                    ("homepage" ,(package-home-page package))
+                                    ("module"   ,(string-drop-right
+                                                  (last (string-split (location-file
+                                                                       (package-location package))
+                                                                      #\/))
+                                                  4)))))))
         (with-atomic-file-output packages-file
           (lambda (port)
             (scm->json (map package->json

--- a/www/pages/welcome.scm
+++ b/www/pages/welcome.scm
@@ -41,46 +41,6 @@
                    (th "Synopsis")
                    (th "Module")
                    (th (@ (style "width: 250pt")) "Homepage")))))
-     (script (@ (type "text/javascript")) "
-// @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-v3-or-later
-function feed_table(packages) {
-    var dt = $('#packages-table').DataTable({
-                sDom: 'lrtip',
-                data: packages,
-                processing: true,
-                createdRow: function (row, data, index) {
-                                $('#stand-by').hide();
-                                $('#packages-table').show();
-                            },
-                columns: [
-                    { data: 'name',
-                      mRender: function (data, type, full) {
-                                  return '" (a (@ (href "package/' + data + '")) "' + data + '") "';
-                               }
-                    },
-                    { data: 'version' },
-                    { data: 'synopsis' },
-                    { data: 'module',
-                      visible: false
-                    },
-                    { data: 'homepage',
-                      mRender: function (data, type, full) {
-                                  return '" (a (@ (href "' + data + '")) "' + data + '") "';
-                               }
-                    }
-                ]});
-    $('#search-field').on('keyup', function() {
-        dt.search(this.value).draw();
-    });
-    $('#search-field').on('keydown', function(event) {
-        if (event.which == 13) return false;
-    });
-
-}
-$(document).ready(function() {
-    $('#packages-table').hide();
-    $.getJSON('/packages.json', feed_table);
-});
-// @license-end
-"))
+     (script (@ (type "text/javascript")
+                (src "/static/hpcguix-web.min.js")) ""))
    #:dependencies '(datatables)))

--- a/www/pages/welcome.scm
+++ b/www/pages/welcome.scm
@@ -1,4 +1,5 @@
 ;;; Copyright © 2017  Roel Janssen <roel@gnu.org>
+;;; Copyright © 2017  Ricardo Wurmus <rekado@elephly.net>
 ;;;
 ;;; This program is free software: you can redistribute it and/or
 ;;; modify it under the terms of the GNU Affero General Public License
@@ -38,6 +39,7 @@
                    (th "Name")
                    (th "Version")
                    (th "Synopsis")
+                   (th "Module")
                    (th (@ (style "width: 250pt")) "Homepage")))))
      (script (@ (type "text/javascript")) "
 // @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-v3-or-later
@@ -58,6 +60,9 @@ function feed_table(packages) {
                     },
                     { data: 'version' },
                     { data: 'synopsis' },
+                    { data: 'module',
+                      visible: false
+                    },
                     { data: 'homepage',
                       mRender: function (data, type, full) {
                                   return '" (a (@ (href "' + data + '")) "' + data + '") "';


### PR DESCRIPTION
Here are a bunch of patches that improve the search (+ a few maintenance commits).

* The first commit just avoids an awful conflict between the guix module and the guix.scm environment file.
* The second commit adds a hidden 'module' column, so that a search for "bioinfo" shows all packages in the bioinformatics module, even if the package name/synopsis don't include the string "bioinfo".
* The inline script has been moved to a new file, primarily because I didn't want to figure out how to stop Guile from entity-encoding `>` and `&&` in the script string.
* Advanced queries are now possible.  Here are some examples:

`name:minimal$` (all packages with a name ending on "minimal")
`name:macs module:bio` (the only "macs" package in the bioinfo module)
`efficient version:3` (anything matching "efficient" with a version string containing "3")

* The last commit confines all these new function definitions to the hpcguix namespace variable, so that they don't pollute the global namespace. 